### PR TITLE
Update nll_co_teaching.py

### DIFF
--- a/pymic/net_run_nll/nll_co_teaching.py
+++ b/pymic/net_run_nll/nll_co_teaching.py
@@ -32,7 +32,7 @@ class BiNet(nn.Module):
         if(self.training):
           return out1, out2
         else:
-          return (out1 + out2) / 3
+          return (out1 + out2) / 2
 
 class NLLCoTeaching(SegmentationAgent):
     """


### PR DESCRIPTION
bug fixed:  In co-teaching, BiNet is expected to output the average of net1 and net2 (Divide by 2 instead of 3 )  when testing.